### PR TITLE
Create an endpoint in Invoker to get current logged-in user's status

### DIFF
--- a/invoker/src/main/java/org.sefglobal.invoker/dto/AuthData.java
+++ b/invoker/src/main/java/org.sefglobal.invoker/dto/AuthData.java
@@ -2,13 +2,14 @@ package org.sefglobal.invoker.dto;
 
 import java.io.Serializable;
 
-public class Token implements Serializable {
+public class AuthData implements Serializable {
 
     private static final long serialVersionUID = -7212868256388049980L;
 
     private String clientCredentials;
     private String accessToken;
     private String refreshToken;
+    private String username;
 
     public String getClientCredentials() {
         return clientCredentials;
@@ -32,5 +33,13 @@ public class Token implements Serializable {
 
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 }

--- a/invoker/src/main/java/org.sefglobal.invoker/service/InvokerController.java
+++ b/invoker/src/main/java/org.sefglobal.invoker/service/InvokerController.java
@@ -1,10 +1,11 @@
 package org.sefglobal.invoker.service;
 
+import org.apache.http.Consts;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.*;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.sefglobal.invoker.dto.Token;
+import org.sefglobal.invoker.dto.AuthData;
 import org.sefglobal.invoker.exception.HTTPClientCreationException;
 import org.sefglobal.invoker.util.Constants;
 import org.sefglobal.invoker.util.InvokerUtil;
@@ -138,8 +139,8 @@ public class InvokerController {
                 response = InvokerUtil.execute(executor, 3);
             }else{
                 HttpSession session = req.getSession(false);
-                Token token = (Token) session.getAttribute(Constants.ATTR_TOKEN);
-                response = InvokerUtil.execute(executor, 3, token);
+                AuthData authData = (AuthData) session.getAttribute(Constants.ATTR_TOKEN);
+                response = InvokerUtil.execute(executor, 3, authData);
             }
         } catch (HTTPClientCreationException e) {
             resp.sendError(500, "Internal Server Error");
@@ -159,6 +160,8 @@ public class InvokerController {
         }
         String result = resultBuffer.toString();
         resp.setStatus(response.getStatusLine().getStatusCode());
+        resp.setContentType(ContentType.APPLICATION_JSON.getMimeType());
+        resp.setCharacterEncoding(Consts.UTF_8.name());
         rd.close();
         return result;
     }

--- a/invoker/src/main/java/org.sefglobal.invoker/service/LoginController.java
+++ b/invoker/src/main/java/org.sefglobal.invoker/service/LoginController.java
@@ -2,7 +2,7 @@ package org.sefglobal.invoker.service;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
-import org.sefglobal.invoker.dto.Token;
+import org.sefglobal.invoker.dto.AuthData;
 import org.sefglobal.invoker.exception.HTTPClientCreationException;
 import org.sefglobal.invoker.exception.UnexpectedResponseException;
 import org.sefglobal.invoker.util.Constants;
@@ -42,9 +42,9 @@ public class LoginController {
             ControllerUtility.sendFailureRedirect(request, response);
             return;
         }
-        Token token;
+        AuthData authData;
         try {
-            token = OAuthUtil.generateToken(username, password, "default");
+            authData = OAuthUtil.generateToken(username, password, "default");
         } catch (ParseException | ConnectException | HTTPClientCreationException e) {
             logger.error(e.getMessage());
             response.sendError(500, "Internal Server Error: " + e.getMessage());
@@ -56,7 +56,7 @@ public class LoginController {
             return;
         }
 
-        if (token == null) {
+        if (authData == null) {
             logger.error("Cannot create token for user: " + username);
             response.sendError(500, "Internal Server Error, Cannot create token for user: " + username);
             return;
@@ -66,8 +66,7 @@ public class LoginController {
         if (session == null) {
             session = request.getSession(true);
         }
-        session.setAttribute(Constants.ATTR_TOKEN, token);
-        session.setAttribute(Constants.ATTR_USER_NAME, username);
+        session.setAttribute(Constants.ATTR_TOKEN, authData);
         String returnUri = request.getParameter("ret");
 
         JSONObject resultObj = new JSONObject();
@@ -91,6 +90,5 @@ public class LoginController {
         response.setCharacterEncoding("UTF-8");
         out.print(resultObj.toString());
         out.flush();
-
     }
 }

--- a/invoker/src/main/java/org.sefglobal.invoker/service/UserController.java
+++ b/invoker/src/main/java/org.sefglobal.invoker/service/UserController.java
@@ -1,0 +1,37 @@
+package org.sefglobal.invoker.service;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.apache.http.Consts;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
+import org.json.simple.JSONObject;
+import org.sefglobal.invoker.dto.AuthData;
+import org.sefglobal.invoker.util.Constants;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+    @PostMapping("/user")
+    private void getUser(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        HttpSession session = request.getSession(false);
+        // Send unauthorized response if user not logged-in
+        if (session == null || session.getAttribute(Constants.ATTR_TOKEN) == null) {
+            response.sendError(401, "Unauthorized, Access token not found in the session");
+            return;
+        }
+        response.setContentType(ContentType.APPLICATION_JSON.getMimeType());
+        response.setCharacterEncoding(Consts.UTF_8.name());
+        JSONObject responseObject = new JSONObject();
+        // Add username to the payload
+        responseObject.put("username", ((AuthData)session.getAttribute(Constants.ATTR_TOKEN)).getUsername());
+        try (PrintWriter writer = response.getWriter()) {
+            writer.write(responseObject.toString());
+        }
+    }
+}

--- a/invoker/src/main/java/org.sefglobal.invoker/util/InvokerUtil.java
+++ b/invoker/src/main/java/org.sefglobal.invoker/util/InvokerUtil.java
@@ -5,7 +5,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.sefglobal.invoker.dto.Token;
+import org.sefglobal.invoker.dto.AuthData;
 import org.sefglobal.invoker.exception.HTTPClientCreationException;
 
 import java.io.IOException;
@@ -24,19 +24,19 @@ public final class InvokerUtil {
 
         return client.execute(executor);
     }
-    public static HttpResponse execute(HttpRequestBase executor, int retryCount, Token token)
+    public static HttpResponse execute(HttpRequestBase executor, int retryCount, AuthData authData)
             throws IOException, HTTPClientCreationException {
         if (retryCount == 0) {
             return null;
         }
-        executor.setHeader("Authorization", "Bearer " + token.getAccessToken());
+        executor.setHeader("Authorization", "Bearer " + authData.getAccessToken());
         CloseableHttpClient client = ControllerUtility.getHTTPClient();
 
         HttpResponse response = client.execute(executor);
         if (response.getStatusLine().getStatusCode() == 401) {
             log.info("Token invalid. Renewing token. Attempts left: " + retryCount);
-            OAuthUtil.refreshToken(token);
-            return execute(executor, --retryCount, token);
+            OAuthUtil.refreshToken(authData);
+            return execute(executor, --retryCount, authData);
         }
         return response;
     }

--- a/invoker/src/main/resources/application.properties
+++ b/invoker/src/main/resources/application.properties
@@ -9,5 +9,7 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDial
 logging.level.org.hibernate.type=TRACE
 
 server.port=9090
+server.session.timeout = 1200
+server.session.cookie.max-age= 1200
 
 endpoints.jmx.unique-names = true


### PR DESCRIPTION
## Purpose
The purpose is to fix #19, It is required to have an API to receive $subject in frontend development. 

## Goals
- Get current logged-in users username
- Send 401 status if the user isn't logged-in
- Expire session within some reasonable period

## Approach
- Rename the `Token` bean to `AuthData` and add username property
- Create a new endpoint `POST /user` in the Invoker
- Set session expiry time to 1200 seconds

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PRs
N/A

## Test environment
MacOs 10.15, tomcat9, JDK 1.8

## Learning
[1] Spring Session - Spring Boot 
https://docs.spring.io/spring-session/docs/current/reference/html5/guides/boot-redis.html
[2] Spring boot session timeout 
https://javadeveloperzone.com/spring-boot/spring-boot-tomcat-session-timeout/ 
